### PR TITLE
修复错误的collectd配置

### DIFF
--- a/logstash/plugins/input/collectd.md
+++ b/logstash/plugins/input/collectd.md
@@ -9,7 +9,7 @@ collectd 是一个守护(daemon)进程，用来收集系统性能和提供各种
 ## collectd的安装
 
 ### 软件仓库安装(推荐)
-collectd官方有一个*隐藏*的软件仓库: https://pkg.ci.collectd.org，构建有`RHEL/CentOS`(rpm)，`Debian/Ubuntu`(deb)的软件包，如果你使用的操作系统属于上述，那么推荐使用软件仓库安装。
+collectd官方有一个的[软件仓库](https://collectd.org/download.shtml#debian): https://pkg.ci.collectd.org ，构建有`RHEL/CentOS`(rpm)，`Debian/Ubuntu`(deb)的软件包，如果你使用的操作系统属于上述，那么推荐使用软件仓库安装。
 
 目前collectd官方维护3个版本: `5.4`, `5.5`, `5.6`。根据需要选择合适的版本。
 
@@ -81,39 +81,30 @@ LoadPlugin disk
     IgnoreSelected false
 </Plugin>
 <Plugin network>
-    <Server "10.0.0.1" "25826"> ## logstash 的 IP 地址和 collectd 的数据接收端口号
+    # logstash 的 IP 地址和 collectd 的数据接收端口号>
+    # 如果logstash和collectd在同一台主机上也可以用环回地址127.0.0.1
+    <Server "10.0.0.1" "25826"
     </Server>
 </Plugin>
 ```
 
 ##logstash的配置
-以下配置实现通过 logstash 监听 `25826` 端口，接收从 collectd 发送过来的各项检测数据。注意 `logstash-filter-collectd` 插件本身需要单独安装，logstash 插件安装说明之前已经讲过：
+以下配置实现通过 logstash 监听 `25826` 端口，接收从 collectd 发送过来的各项检测数据。
 
-```
-bin/logstash-plugin install logstash-filter-collectd
-```
+logstash默认自带有`collectd`的codec插件，详见官方文档: https://www.elastic.co/guide/en/logstash/current/plugins-codecs-collectd.html
 
-### 示例一：
+### 示例：
 
 ```ruby
 input {
-    collectd {
-        port => 25826 ## 端口号与发送端对应
-        type => collectd
+    udp {
+        port => 25826
+        buffer_size => 1452
+        workers => 3          # Default is 2
+        queue_size => 30000   # Default is 2000
+        codec => collectd { }
+        type => "collectd"
     }
-}
-```
-
-### 示例二：（推荐）
-
-```ruby
-udp {
-    port => 25826
-    buffer_size => 1452
-    workers => 3          # Default is 2
-    queue_size => 30000   # Default is 2000
-    codec => collectd { }
-    type => "collectd"
 }
 ```
 


### PR DESCRIPTION
collectd早就没有input插件了，官方改为了codec解码collectd数据格式。修改章节内容中老旧废弃的部分。